### PR TITLE
Use a terraform-specific commentstring

### DIFF
--- a/after/ftplugin/terraform.vim
+++ b/after/ftplugin/terraform.vim
@@ -15,3 +15,5 @@ if g:terraform_align && exists(':Tabularize')
     endif
   endfunction
 endif
+
+set commentstring=#%s


### PR DESCRIPTION
The default Vim `commentstring` is the C-style multiline comment ([`/*%s*/`](http://vimhelp.appspot.com/options.txt.html#%27commentstring%27)). While this style of comment is [valid HCL](https://github.com/hashicorp/hcl#syntax), this setting is not too conducive for use with a commenting tool like [vim-commentary](https://github.com/tpope/vim-commentary). Setting the `cms` to a single-line value matches the behavior of `vim-commentary` across other filetypes.

I should mention that, instead of trying to patch this plugin, I could add a line to my vim configuration:

```vim
autocmd FileType terraform setlocal commentstring=#%s
```

I also don't know how other end-users of this plugin would react to a change like this, so I would not be too disappointed if this PR was rejected.